### PR TITLE
Update generator to create a .doclua for each module. 

### DIFF
--- a/generator/main.lua
+++ b/generator/main.lua
@@ -8,25 +8,123 @@ function love.load()
     local api = require('love_api');
 
     love.filesystem.append('love.lua', "module('love')\r\n");
+    love.filesystem.append('love.doclua', DOCLUA);
+    love.filesystem.append('love.doclua', "SIGNATURES = {\r\n");
 
     for i, f in ipairs(api.callbacks) do
         love.filesystem.append('love.lua', 'function ' .. f.name .. '() end\r\n');
+
+        -- Find the args of the first variant
+        local args = {}
+        local variant = f.variants[1]
+
+        if variant.arguments then
+            for ii, a in ipairs(variant.arguments) do
+                table.insert(args, a.name)
+            end
+        end
+        love.filesystem.append('love.doclua', '["love.' .. f.name .. '"] = [=[' .. f.name .. '(' .. table.concat(args, ', ')  .. ') - ' .. f.description .. ']=],\r\n');
     end
 
     for i, f in ipairs(api.functions) do
         love.filesystem.append('love.lua', 'function ' .. f.name .. '() end\r\n');
+
+        -- Find the args of the first variant
+        local args = {}
+        local variant = f.variants[1]
+
+        if variant.arguments then
+            for ii, a in ipairs(variant.arguments) do
+                table.insert(args, a.name)
+            end
+        end
+        love.filesystem.append('love.doclua', '["love.' .. f.name .. '"] = [=[' .. f.name .. '(' .. table.concat(args, ', ')  .. ') - ' .. f.description .. ']=],\r\n');
     end
+
+    love.filesystem.append('love.doclua', "}\r\n");
 
     for i, m in ipairs(api.modules) do
         love.filesystem.append(m.name .. '.lua', "module('love." .. m.name .. "')\r\n\n");
+        love.filesystem.append(m.name .. '.doclua', DOCLUA);
+        love.filesystem.append(m.name .. '.doclua', "SIGNATURES = {\r\n");
+        love.filesystem.append(m.name .. '.doclua', '["love.' .. m.name .. '"] = [=[love.' .. m.name .. ' - ' .. m.description .. ']=],\r\n');
         for ii, f in ipairs(m.functions) do
             love.filesystem.append(m.name .. '.lua', 'function ' .. f.name .. '() end\r\n');
+            -- Find the args of the first variant
+            local args = {}
+            local variant = f.variants[1]
+
+            if variant.arguments then
+                for ii, a in ipairs(variant.arguments) do
+                    table.insert(args, a.name)
+                end
+            end
+            love.filesystem.append(m.name .. '.doclua', '["love.' .. m.name .. '.' .. f.name .. '"] = [=[' .. f.name .. '(' .. table.concat(args, ', ')  .. ') - ' .. f.description .. ']=],\r\n');
         end
+        love.filesystem.append(m.name .. '.doclua', "}\r\n");
     end
 
     print('Done!');
     love.event.quit();
 end
+
+DOCLUA = [=[
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+]=]
+
 
 --==================================================================================================
 -- Created 14.09.14 - 22:09                                                                        =

--- a/love_010/audio.doclua
+++ b/love_010/audio.doclua
@@ -1,0 +1,76 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.audio"] = [=[love.audio - Provides an interface to create noise with the user's speakers.]=],
+["love.audio.getDistanceModel"] = [=[getDistanceModel() - Returns the distance attenuation model.]=],
+["love.audio.getDopplerScale"] = [=[getDopplerScale() - Gets the current global scale factor for velocity-based doppler effects.]=],
+["love.audio.getSourceCount"] = [=[getSourceCount() - Returns the number of sources which are currently playing or paused.]=],
+["love.audio.getOrientation"] = [=[getOrientation() - Returns the orientation of the listener.]=],
+["love.audio.getPosition"] = [=[getPosition() - Returns the position of the listener.]=],
+["love.audio.getVelocity"] = [=[getVelocity() - Returns the velocity of the listener.]=],
+["love.audio.getVolume"] = [=[getVolume() - Returns the master volume.]=],
+["love.audio.newSource"] = [=[newSource(filename, type) - Creates a new Source from a file or SoundData. Sources created from SoundData are always static.]=],
+["love.audio.pause"] = [=[pause() - Pauses all audio]=],
+["love.audio.play"] = [=[play(source) - Plays the specified Source.]=],
+["love.audio.resume"] = [=[resume() - Resumes all audio]=],
+["love.audio.rewind"] = [=[rewind() - Rewinds all playing audio.]=],
+["love.audio.setDistanceModel"] = [=[setDistanceModel(model) - Sets the distance attenuation model.]=],
+["love.audio.setDopplerScale"] = [=[setDopplerScale(scale) - Sets a global scale factor for velocity-based doppler effects. The default scale value is 1.]=],
+["love.audio.setOrientation"] = [=[setOrientation(fx, fy, fz, ux, uy, uz) - Sets the orientation of the listener.]=],
+["love.audio.setPosition"] = [=[setPosition(x, y, z) - Sets the position of the listener, which determines how sounds play.]=],
+["love.audio.setVelocity"] = [=[setVelocity(x, y, z) - Sets the velocity of the listener.]=],
+["love.audio.setVolume"] = [=[setVolume(volume) - Sets the master volume.]=],
+["love.audio.stop"] = [=[stop() - Stops all playing audio.]=],
+}

--- a/love_010/event.doclua
+++ b/love_010/event.doclua
@@ -1,0 +1,65 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.event"] = [=[love.event - Manages events, like keypresses.]=],
+["love.event.clear"] = [=[clear() - Clears the event queue.]=],
+["love.event.poll"] = [=[poll() - Returns an iterator for messages in the event queue.]=],
+["love.event.pump"] = [=[pump() - Pump events into the event queue. This is a low-level function, and is usually not called by the user, but by love.run. Note that this does need to be called for any OS to think you're still running, and if you want to handle OS-generated events at all (think callbacks). love.event.pump can only be called from the main thread, but afterwards, the rest of love.event can be used from any other thread.]=],
+["love.event.push"] = [=[push(e, a, b, c, d) - Adds an event to the event queue.]=],
+["love.event.quit"] = [=[quit() - Adds the quit event to the queue.
+
+The quit event is a signal for the event handler to close LÖVE. It's possible to abort the exit process with the love.quit callback.]=],
+["love.event.wait"] = [=[wait() - Like love.event.poll but blocks until there is an event in the queue.]=],
+}

--- a/love_010/filesystem.doclua
+++ b/love_010/filesystem.doclua
@@ -1,0 +1,111 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.filesystem"] = [=[love.filesystem - Provides an interface to the user's filesystem.]=],
+["love.filesystem.append"] = [=[append(name, data, size) - Append data to an existing file.]=],
+["love.filesystem.areSymlinksEnabled"] = [=[areSymlinksEnabled() - Gets whether love.filesystem follows symbolic links.]=],
+["love.filesystem.createDirectory"] = [=[createDirectory(name) - Creates a directory.]=],
+["love.filesystem.exists"] = [=[exists(filename) - Check whether a file or directory exists.]=],
+["love.filesystem.getAppdataDirectory"] = [=[getAppdataDirectory() - Returns the application data directory (could be the same as getUserDirectory)]=],
+["love.filesystem.getDirectoryItems"] = [=[getDirectoryItems(dir) - Returns a table with the names of files and subdirectories in the specified path. The table is not sorted in any way; the order is undefined.
+
+If the path passed to the function exists in the game and the save directory, it will list the files and directories from both places.]=],
+["love.filesystem.getIdentity"] = [=[getIdentity(name) - Gets the write directory name for your game. Note that this only returns the name of the folder to store your files in, not the full location.]=],
+["love.filesystem.getLastModified"] = [=[getLastModified(filename) - Gets the last modification time of a file.]=],
+["love.filesystem.getRealDirectory"] = [=[getRealDirectory(filepath) - Gets the platform-specific absolute path of the directory containing a filepath.
+
+This can be used to determine whether a file is inside the save directory or the game's source .love.]=],
+["love.filesystem.getRequirePath"] = [=[getRequirePath() - Gets the filesystem paths that will be searched when require is called.
+
+The paths string returned by this function is a sequence of path templates separated by semicolons. The argument passed to require will be inserted in place of any question mark ("?") character in each template (after the dot characters in the argument passed to require are replaced by directory separators.)
+
+The paths are relative to the game's source and save directories, as well as any paths mounted with love.filesystem.mount.]=],
+["love.filesystem.getSaveDirectory"] = [=[getSaveDirectory() - Gets the full path to the designated save directory. This can be useful if you want to use the standard io library (or something else) to read or write in the save directory.]=],
+["love.filesystem.getSize"] = [=[getSize(filename) - Gets the size in bytes of a file.]=],
+["love.filesystem.getSourceBaseDirectory"] = [=[getSourceBaseDirectory() - Returns the full path to the directory containing the .love file. If the game is fused to the LÖVE executable, then the directory containing the executable is returned.
+
+If love.filesystem.isFused is true, the path returned by this function can be passed to love.filesystem.mount, which will make the directory containing the main game readable by love.filesystem.]=],
+["love.filesystem.getUserDirectory"] = [=[getUserDirectory() - Returns the path of the user's directory.]=],
+["love.filesystem.getWorkingDirectory"] = [=[getWorkingDirectory() - Gets the current working directory.]=],
+["love.filesystem.isDirectory"] = [=[isDirectory(path) - Check whether something is a directory.]=],
+["love.filesystem.isFile"] = [=[isFile(path) - Check whether something is a file.]=],
+["love.filesystem.isFused"] = [=[isFused() - Gets whether the game is in fused mode or not.
+
+If a game is in fused mode, its save directory will be directly in the Appdata directory instead of Appdata/LOVE/. The game will also be able to load C Lua dynamic libraries which are located in the save directory.
+
+A game is in fused mode if the source .love has been fused to the executable (see Game Distribution), or if "--fused" has been given as a command-line argument when starting the game.]=],
+["love.filesystem.isSymlink"] = [=[isSymlink(path) - Gets whether a filepath is actually a symbolic link.
+
+If symbolic links are not enabled (via love.filesystem.setSymlinksEnabled), this function will always return false.]=],
+["love.filesystem.lines"] = [=[lines(name) - Iterate over the lines in a file.]=],
+["love.filesystem.load"] = [=[load(name) - Load a file (but not run it).]=],
+["love.filesystem.mount"] = [=[mount(archive, mountpoint) - Mounts a zip file or folder in the game's save directory for reading.]=],
+["love.filesystem.newFile"] = [=[newFile(filename, mode) - Creates a new File object. It needs to be opened before it can be accessed.]=],
+["love.filesystem.newFileData"] = [=[newFileData(contents, name, decoder) - Creates a new FileData object.]=],
+["love.filesystem.read"] = [=[read(name, bytes) - Read the contents of a file.]=],
+["love.filesystem.remove"] = [=[remove(name) - Removes a file or directory.]=],
+["love.filesystem.setIdentity"] = [=[setIdentity(name, searchorder) - Sets the write directory for your game. Note that you can only set the name of the folder to store your files in, not the location.]=],
+["love.filesystem.setRequirePath"] = [=[setRequirePath(paths) - Sets the filesystem paths that will be searched when require is called.
+
+The paths string given to this function is a sequence of path templates separated by semicolons. The argument passed to require will be inserted in place of any question mark ("?") character in each template (after the dot characters in the argument passed to require are replaced by directory separators.)
+
+The paths are relative to the game's source and save directories, as well as any paths mounted with love.filesystem.mount.]=],
+["love.filesystem.setSource"] = [=[setSource(path) - Sets the source of the game, where the code is present. This function can only be called once, and is normally automatically done by LÖVE.]=],
+["love.filesystem.setSymlinksEnabled"] = [=[setSymlinksEnabled(enable) - Sets whether love.filesystem follows symbolic links. Sets whether love.filesystem follows symbolic links. It is enabled by default in version 0.10.0 and newer, and disabled by default in 0.9.2.]=],
+["love.filesystem.unmount"] = [=[unmount(archive) - Unmounts a zip file or folder previously mounted for reading with love.filesystem.mount.]=],
+["love.filesystem.write"] = [=[write(name, data, size) - Write data to a file.
+
+If you are getting the error message "Could not set write directory", try setting the save directory. This is done either with love.filesystem.setIdentity or by setting the identity field in love.conf.]=],
+}

--- a/love_010/graphics.doclua
+++ b/love_010/graphics.doclua
@@ -1,0 +1,258 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.graphics"] = [=[love.graphics - The primary responsibility for the love.graphics module is the drawing of lines, shapes, text, Images and other Drawable objects onto the screen. Its secondary responsibilities include loading external files (including Images and Fonts) into memory, creating specialized objects (such as ParticleSystems or Framebuffers) and managing screen geometry.
+
+LÖVE's coordinate system is rooted in the upper-left corner of the screen, which is at location (0, 0). The x-axis is horizontal: larger values are further to the right. The y-axis is vertical: larger values are further towards the bottom.
+
+In many cases, you draw images or shapes in terms of their upper-left corner (See the picture above).
+
+Many of the functions are used to manipulate the graphics coordinate system, which is essentially the way coordinates are mapped to the display. You can change the position, scale, and even rotation in this way.]=],
+["love.graphics.arc"] = [=[arc(mode, x, y, radius, angle1, angle2, segments) - Draws an arc.]=],
+["love.graphics.circle"] = [=[circle(mode, x, y, radius, segments) - Draws a circle.]=],
+["love.graphics.clear"] = [=[clear() - Clears the screen to the background color in LÖVE 0.9.2 and earlier, or to the specified color in 0.10.0 and newer.
+
+This function is called automatically before love.draw in the default love.run function. See the example in love.run for a typical use of this function.
+
+Note that the scissor area bounds the cleared region.]=],
+["love.graphics.discard"] = [=[discard(discardcolor, discardstencil) - Discards (trashes) the contents of the screen or active Canvas. This is a performance optimization function with niche use cases.
+
+If the active Canvas has just been changed and the "replace" BlendMode is about to be used to draw something which covers the entire screen, calling love.graphics.discard rather than calling love.graphics.clear or doing nothing may improve performance on mobile devices.
+
+On some desktop systems this function may do nothing.]=],
+["love.graphics.draw"] = [=[draw(drawable, x, y, r, sx, sy, ox, oy, kx, ky) - Draws objects on screen. Drawable objects are loaded images, but may be other kinds of Drawable objects, such as a ParticleSystem.
+
+In addition to simple drawing, this function can rotate and scale the object at the same time, as well as offset the image (for example, to center the image at the chosen coordinates).
+
+love.graphics.draw anchors from the top left corner by default.
+
+You can specify a negative value for sx or sy to flip the drawable horizontally or vertically.
+
+The pivotal point is (x, y) on the screen and (ox, oy) in the internal coordinate system of the drawable object, before rotation and scaling. The object is scaled by (sx, sy), then rotated by r around the pivotal point.
+
+The origin offset values are most often used to shift the images up and left by half of its height and width, so that (effectively) the specified x and y coordinates are where the center of the image will end up.]=],
+["love.graphics.ellipse"] = [=[ellipse(mode, x, y, radiusx, radiusy) - Draws an ellipse.]=],
+["love.graphics.getBackgroundColor"] = [=[getBackgroundColor() - Gets the current background color.]=],
+["love.graphics.getBlendMode"] = [=[getBlendMode() - Gets the blending mode.]=],
+["love.graphics.getCanvas"] = [=[getCanvas() - Gets the current target Canvas.]=],
+["love.graphics.getCanvasFormats"] = [=[getCanvasFormats() - Gets the available Canvas formats, and whether each is supported.]=],
+["love.graphics.getColor"] = [=[getColor() - Gets the current color.]=],
+["love.graphics.getColorMask"] = [=[getColorMask() - Gets the active color components used when drawing. Normally all 4 components are active unless love.graphics.setColorMask has been used.
+
+The color mask determines whether individual components of the colors of drawn objects will affect the color of the screen. They affect love.graphics.clear and Canvas:clear as well.]=],
+["love.graphics.getCompressedImageFormats"] = [=[getCompressedImageFormats() - Gets the available compressed image formats, and whether each is supported.]=],
+["love.graphics.getDefaultFilter"] = [=[getDefaultFilter() - Returns the default scaling filters used with Images, Canvases, and Fonts.]=],
+["love.graphics.getDimensions"] = [=[getDimensions() - Gets the width and height of the window.]=],
+["love.graphics.getFSAA"] = [=[getFSAA() - Gets the number of antialiasing samples used when drawing to the Canvas.
+
+This may be different than the number used as an argument to love.graphics.newCanvas if the system running LÖVE doesn't support that number.]=],
+["love.graphics.getFont"] = [=[getFont() - Gets the current Font object.]=],
+["love.graphics.getHeight"] = [=[getHeight() - Gets the height of the window.]=],
+["love.graphics.getLineJoin"] = [=[getLineJoin() - Gets the line join style.]=],
+["love.graphics.getLineStyle"] = [=[getLineStyle() - Gets the line style.]=],
+["love.graphics.getLineWidth"] = [=[getLineWidth() - Gets the current line width.]=],
+["love.graphics.getFullscreenModes"] = [=[getFullscreenModes() - Gets a list of supported fullscreen modes.]=],
+["love.graphics.getShader"] = [=[getShader() - Returns the current Shader. Returns nil if none is set.]=],
+["love.graphics.getStats"] = [=[getStats() - Gets performance-related rendering statistics.]=],
+["love.graphics.getStencilTest"] = [=[getStencilTest() - Gets whether stencil testing is enabled.
+
+When stencil testing is enabled, the geometry of everything that is drawn will be clipped / stencilled out based on whether it intersects with what has been previously drawn to the stencil buffer.
+
+Each Canvas has its own stencil buffer.]=],
+["love.graphics.getSupported"] = [=[getSupported() - Gets the optional graphics features and whether they're supported on the system.
+
+Some older or low-end systems don't always support all graphics features.]=],
+["love.graphics.getSystemLimits"] = [=[getSystemLimits() - Gets the system-dependent maximum values for love.graphics features.]=],
+["love.graphics.getPointSize"] = [=[getPointSize() - Gets the point size.]=],
+["love.graphics.getRendererInfo"] = [=[getRendererInfo() - Gets information about the system's video card and drivers.]=],
+["love.graphics.getScissor"] = [=[getScissor() - Gets the current scissor box.]=],
+["love.graphics.getWidth"] = [=[getWidth() - Gets the width of the window.]=],
+["love.graphics.intersectScissor"] = [=[intersectScissor(x, y, width, height) - Sets the scissor to the rectangle created by the intersection of the specified rectangle with the existing scissor. If no scissor is active yet, it behaves like love.graphics.setScissor.
+
+The scissor limits the drawing area to a specified rectangle. This affects all graphics calls, including love.graphics.clear.
+
+The dimensions of the scissor is unaffected by graphical transformations (translate, scale, ...).]=],
+["love.graphics.isGammaCorrect"] = [=[isGammaCorrect() - Gets whether gamma-correct rendering is supported and enabled. It can be enabled by setting t.gammacorrect = true in love.conf.
+
+Not all devices support gamma-correct rendering, in which case it will be automatically disabled and this function will return false. It is supported on desktop systems which have graphics cards that are capable of using OpenGL 3 / DIrectX 10, and iOS devices that can use OpenGL ES 3.]=],
+["love.graphics.isWireframe"] = [=[isWireframe() - Gets whether wireframe mode is used when drawing.]=],
+["love.graphics.line"] = [=[line(x1, y1, x2, y2, ...) - Draws lines between points.]=],
+["love.graphics.newCanvas"] = [=[newCanvas(width, height, texture_type, fsaa) - Creates a new Canvas object for offscreen rendering.
+
+Antialiased Canvases have slightly higher system requirements than normal Canvases. Additionally, the supported maximum number of FSAA samples varies depending on the system. Use love.graphics.getSystemLimit to check.
+
+If the number of FSAA samples specified is greater than the maximum supported by the system, the Canvas will still be created but only using the maximum supported amount (this includes 0.)]=],
+["love.graphics.newFont"] = [=[newFont(filename, size) - Creates a new Font.]=],
+["love.graphics.newMesh"] = [=[newMesh(vertices, mode, usage) - Creates a new Mesh.
+
+Use Mesh:setTexture if the Mesh should be textured with an Image or Canvas when it's drawn.]=],
+["love.graphics.newImage"] = [=[newImage(filename) - Creates a new Image from a filepath, FileData, an ImageData, or a CompressedImageData, and optionally generates or specifies mipmaps for the image.]=],
+["love.graphics.newImageFont"] = [=[newImageFont(filename, glyphs) - Creates a new Font by loading a specifically formatted image. There can be up to 256 glyphs.
+
+In versions prior to 0.9.0, LÖVE expects ISO 8859-1 encoding for the glyphs string.]=],
+["love.graphics.newParticleSystem"] = [=[newParticleSystem(texture, buffer) - Creates a new ParticleSystem.]=],
+["love.graphics.newShader"] = [=[newShader(code) - Creates a new Shader object for hardware-accelerated vertex and pixel effects. A Shader contains either vertex shader code, pixel shader code, or both.
+
+Vertex shader code must contain at least one function, named position, which is the function that will produce transformed vertex positions of drawn objects in screen-space.
+
+Pixel shader code must contain at least one function, named effect, which is the function that will produce the color which is blended onto the screen for each pixel a drawn object touches.]=],
+["love.graphics.newText"] = [=[newText(font, textstring) - Creates a new Font.]=],
+["love.graphics.newQuad"] = [=[newQuad(x, y, width, height, sw, sh) - Creates a new Quad.
+
+The purpose of a Quad is to describe the result of the following transformation on any drawable object. The object is first scaled to dimensions sw * sh. The Quad then describes the rectangular area of dimensions width * height whose upper left corner is at position (x, y) inside the scaled object.]=],
+["love.graphics.newScreenshot"] = [=[newScreenshot() - Creates a screenshot and returns the image data.]=],
+["love.graphics.newSpriteBatch"] = [=[newSpriteBatch(texture, size, usage) - Creates a new SpriteBatch object.]=],
+["love.graphics.newVideo"] = [=[newVideo(filename, loadaudio) - Creates a new drawable Video. Currently only Ogg Theora video files are supported.]=],
+["love.graphics.origin"] = [=[origin() - Resets the current coordinate transformation.
+
+This function is always used to reverse any previous calls to love.graphics.rotate, love.graphics.scale, love.graphics.shear or love.graphics.translate. It returns the current transformation state to its defaults.]=],
+["love.graphics.points"] = [=[points(x, y, ...) - Draws one or more points.]=],
+["love.graphics.polygon"] = [=[polygon(mode, ...) - Draw a polygon.
+
+Following the mode argument, this function can accept multiple numeric arguments or a single table of numeric arguments. In either case the arguments are interpreted as alternating x and y coordinates of the polygon's vertices.
+
+When in fill mode, the polygon must be convex and simple or rendering artifacts may occur.]=],
+["love.graphics.pop"] = [=[pop() - Pops the current coordinate transformation from the transformation stack.
+
+This function is always used to reverse a previous push operation. It returns the current transformation state to what it was before the last preceding push. For an example, see the description of love.graphics.push.]=],
+["love.graphics.present"] = [=[present() - Displays the results of drawing operations on the screen.
+
+This function is used when writing your own love.run function. It presents all the results of your drawing operations on the screen. See the example in love.run for a typical use of this function.]=],
+["love.graphics.print"] = [=[print(text, x, y, r, sx, sy, ox, oy, kx, ky) - Draws text on screen. If no Font is set, one will be created and set (once) if needed.
+
+When using translation and scaling functions while drawing text, this function assumes the scale occurs first. If you don't script with this in mind, the text won't be in the right position, or possibly even on screen.
+
+love.graphics.print stops at the first ' ' (null) character. This can bite you if you are appending keystrokes to form your string, as some of those are multi-byte unicode characters which will likely contain null bytes.]=],
+["love.graphics.printf"] = [=[printf(text, x, y, limit, align, r, sx, sy, ox, oy, kx, ky) - Draws formatted text, with word wrap and alignment.
+
+See additional notes in love.graphics.print.]=],
+["love.graphics.push"] = [=[push() - Copies and pushes the current coordinate transformation to the transformation stack.
+
+This function is always used to prepare for a corresponding pop operation later. It stores the current coordinate transformation state into the transformation stack and keeps it active. Later changes to the transformation can be undone by using the pop operation, which returns the coordinate transform to the state it was in before calling push.]=],
+["love.graphics.rectangle"] = [=[rectangle(mode, x, y, width, height) - Draws a rectangle.]=],
+["love.graphics.reset"] = [=[reset() - Resets the current graphics settings.
+
+Calling reset makes the current drawing color white, the current background color black, resets any active Canvas or Shader, and removes any scissor settings. It sets the BlendMode to alpha. It also sets both the point and line drawing modes to smooth and their sizes to 1.0.]=],
+["love.graphics.rotate"] = [=[rotate(angle) - Rotates the coordinate system in two dimensions.
+
+Calling this function affects all future drawing operations by rotating the coordinate system around the origin by the given amount of radians. This change lasts until love.draw exits.]=],
+["love.graphics.scale"] = [=[scale(sx, sy) - Scales the coordinate system in two dimensions.
+
+By default the coordinate system in LÖVE corresponds to the display pixels in horizontal and vertical directions one-to-one, and the x-axis increases towards the right while the y-axis increases downwards. Scaling the coordinate system changes this relation.
+
+After scaling by sx and sy, all coordinates are treated as if they were multiplied by sx and sy. Every result of a drawing operation is also correspondingly scaled, so scaling by (2, 2) for example would mean making everything twice as large in both x- and y-directions. Scaling by a negative value flips the coordinate system in the corresponding direction, which also means everything will be drawn flipped or upside down, or both. Scaling by zero is not a useful operation.
+
+Scale and translate are not commutative operations, therefore, calling them in different orders will change the outcome.
+
+Scaling lasts until love.draw exits.]=],
+["love.graphics.setBackgroundColor"] = [=[setBackgroundColor(r, g, b, a) - Sets the background color.]=],
+["love.graphics.setBlendMode"] = [=[setBlendMode(mode) - Sets the blending mode.]=],
+["love.graphics.setCanvas"] = [=[setCanvas() - Sets the render target to one or more Canvases. All drawing operations until the next love.graphics.setCanvas call will be redirected to the specified canvases and not shown on the screen.
+
+All canvas arguments must have the same widths and heights and the same texture type. Normally the same thing will be drawn on each canvas, but that can be changed if a pixel shader is used with the "effects" function instead of the regular effect.
+
+Not all computers support Canvases, and not all computers which support Canvases will support multiple render targets. Use love.graphics.isSupported to check.
+
+nWhen called without arguments, the render target is reset to the screen.]=],
+["love.graphics.setColor"] = [=[setColor(red, green, blue, alpha) - Sets the color used for drawing.]=],
+["love.graphics.setColorMask"] = [=[setColorMask() - Sets the color mask. Enables or disables specific color components when rendering and clearing the screen. For example, if red is set to false, no further changes will be made to the red component of any pixels.
+
+Enables all color components when called without arguments.]=],
+["love.graphics.setDefaultFilter"] = [=[setDefaultFilter(min, mag, anisotropy) - Sets the default scaling filters used with Images, Canvases, and Fonts.
+
+This function does not apply retroactively to loaded images.]=],
+["love.graphics.setFont"] = [=[setFont(font) - Set an already-loaded Font as the current font or create and load a new one from the file and size.
+
+It's recommended that Font objects are created with love.graphics.newFont in the loading stage and then passed to this function in the drawing stage.]=],
+["love.graphics.setInvertedStencil"] = [=[setInvertedStencil() - Defines an inverted stencil for the drawing operations or releases the active one.
+
+It's the same as love.graphics.setStencil with the mask inverted.
+
+Calling the function without arguments releases the active stencil.]=],
+["love.graphics.setLineJoin"] = [=[setLineJoin(join) - Sets the line join style.]=],
+["love.graphics.setLineStyle"] = [=[setLineStyle(style) - Sets the line style.]=],
+["love.graphics.setLineWidth"] = [=[setLineWidth(width) - Sets the line width.]=],
+["love.graphics.setNewFont"] = [=[setNewFont(size) - Creates and sets a new font.]=],
+["love.graphics.setShader"] = [=[setShader() - Sets or resets a Shader as the current pixel effect or vertex shaders. All drawing operations until the next love.graphics.setShader will be drawn using the Shader object specified.
+
+Disables the shaders when called without arguments.]=],
+["love.graphics.setPointSize"] = [=[setPointSize(size) - Sets the point size.]=],
+["love.graphics.setScissor"] = [=[setScissor(x, y, width, height) - Sets or disables scissor.
+
+The scissor limits the drawing area to a specified rectangle. This affects all graphics calls, including love.graphics.clear.]=],
+["love.graphics.setStencilTest"] = [=[setStencilTest(comparemode, comparevalue) - Configures or disables stencil testing.
+
+When stencil testing is enabled, the geometry of everything that is drawn afterward will be clipped / stencilled out based on a comparison between the arguments of this function and the stencil value of each pixel that the geometry touches. The stencil values of pixels are affected via love.graphics.stencil.
+
+Each Canvas has its own per-pixel stencil values.]=],
+["love.graphics.setWireframe"] = [=[setWireframe(enable) - Sets whether wireframe lines will be used when drawing.
+
+Wireframe mode should only be used for debugging. The lines drawn with it enabled do not behave like regular love.graphics lines: their widths don't scale with the coordinate transformations or with love.graphics.setLineWidth, and they don't use the smooth LineStyle.]=],
+["love.graphics.shear"] = [=[shear(kx, ky) - Shears the coordinate system.]=],
+["love.graphics.stencil"] = [=[stencil(stencilfunction, action, value, keepvalues) - Draws geometry as a stencil.
+
+The geometry drawn by the supplied function sets invisible stencil values of pixels, instead of setting pixel colors. The stencil values of pixels can act like a mask / stencil - love.graphics.setStencilTest can be used afterward to determine how further rendering is affected by the stencil values in each pixel.
+
+Each Canvas has its own per-pixel stencil values. Stencil values are within the range of [0, 255].]=],
+["love.graphics.translate"] = [=[translate(dx, dy) - Translates the coordinate system in two dimensions.
+
+When this function is called with two numbers, dx, and dy, all the following drawing operations take effect as if their x and y coordinates were x+dx and y+dy.
+
+Scale and translate are not commutative operations, therefore, calling them in different orders will change the outcome.
+
+This change lasts until love.graphics.clear is called (which is called automatically before love.draw in the default love.run function), or a love.graphics.pop reverts to a previous coordinate system state.
+
+Translating using whole numbers will prevent tearing/blurring of images and fonts draw after translating.]=],
+}

--- a/love_010/image.doclua
+++ b/love_010/image.doclua
@@ -1,0 +1,60 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.image"] = [=[love.image - Provides an interface to decode encoded image data.]=],
+["love.image.isCompressed"] = [=[isCompressed(filename) - Determines whether a file can be loaded as CompressedData.]=],
+["love.image.newCompressedData"] = [=[newCompressedData(filename) - Create a new CompressedImageData object from a compressed image file. LÖVE supports several compressed texture formats, enumerated in the CompressedImageFormat page.]=],
+["love.image.newImageData"] = [=[newImageData(width, height) - Create a new ImageData object.]=],
+}

--- a/love_010/joystick.doclua
+++ b/love_010/joystick.doclua
@@ -1,0 +1,66 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.joystick"] = [=[love.joystick - Provides an interface to the user's joystick.]=],
+["love.joystick.getJoystickCount"] = [=[getJoystickCount() - Gets the number of connected joysticks.]=],
+["love.joystick.getJoysticks"] = [=[getJoysticks() - Gets a list of connected Joysticks.]=],
+["love.joystick.loadGamepadMappings"] = [=[loadGamepadMappings(filename) - Loads a gamepad mappings string or file created with love.joystick.saveGamepadMappings.]=],
+["love.joystick.saveGamepadMappings"] = [=[saveGamepadMappings(filename) - Saves the virtual gamepad mappings of all Joysticks that are recognized as gamepads and have either been recently used or their gamepad bindings have been modified.]=],
+["love.joystick.setGamepadMapping"] = [=[setGamepadMapping(guid, button, inputtype, inputindex, hatdirection) - Binds a virtual gamepad input to a button, axis or hat for all Joysticks of a certain type. For example, if this function is used with a GUID returned by a Dualshock 3 controller in OS X, the binding will affect Joystick:getGamepadAxis and Joystick:isGamepadDown for all Dualshock 3 controllers used with the game when run in OS X.
+
+LÖVE includes built-in gamepad bindings for many common controllers. This function lets you change the bindings or add new ones for types of Joysticks which aren't recognized as gamepads by default.
+
+The virtual gamepad buttons and axes are designed around the Xbox 360 controller layout.]=],
+}

--- a/love_010/keyboard.doclua
+++ b/love_010/keyboard.doclua
@@ -1,0 +1,77 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.keyboard"] = [=[love.keyboard - Provides an interface to the user's keyboard.]=],
+["love.keyboard.getKeyFromScancode"] = [=[getKeyFromScancode(scancode) - Gets the key corresponding to the given hardware scancode.
+
+Unlike key constants, Scancodes are keyboard layout-independent. For example the scancode "w" will be generated if the key in the same place as the "w" key on an American keyboard is pressed, no matter what the key is labelled or what the user's operating system settings are.
+
+Scancodes are useful for creating default controls that have the same physical locations on on all systems.]=],
+["love.keyboard.getScancodeFromKey"] = [=[getScancodeFromKey(key) - Gets the hardware scancode corresponding to the given key.
+
+Unlike key constants, Scancodes are keyboard layout-independent. For example the scancode "w" will be generated if the key in the same place as the "w" key on an American keyboard is pressed, no matter what the key is labelled or what the user's operating system settings are.
+
+Scancodes are useful for creating default controls that have the same physical locations on on all systems.]=],
+["love.keyboard.hasKeyRepeat"] = [=[hasKeyRepeat() - Gets whether key repeat is enabled.]=],
+["love.keyboard.hasTextInput"] = [=[hasTextInput() - Gets whether text input events are enabled.]=],
+["love.keyboard.isDown"] = [=[isDown(key) - Checks whether a certain key is down. Not to be confused with love.keypressed or love.keyreleased.]=],
+["love.keyboard.isScancodeDown"] = [=[isScancodeDown(scancode, ...) - Checks whether the specified Scancodes are pressed. Not to be confused with love.keypressed or love.keyreleased.
+
+Unlike regular KeyConstants, Scancodes are keyboard layout-independent. The scancode "w" is used if the key in the same place as the "w" key on an American keyboard is pressed, no matter what the key is labelled or what the user's operating system settings are.]=],
+["love.keyboard.setKeyRepeat"] = [=[setKeyRepeat(enable) - Enables or disables key repeat. It is disabled by default.
+
+The interval between repeats depends on the user's system settings.]=],
+["love.keyboard.setTextInput"] = [=[setTextInput(enable) - Enables or disables text input events. It is enabled by default on Windows, Mac, and Linux, and disabled by default on iOS and Android.]=],
+}

--- a/love_010/love.doclua
+++ b/love_010/love.doclua
@@ -1,0 +1,99 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.directorydropped"] = [=[directorydropped(path) - Callback function triggered when a directory is dragged and dropped onto the window.]=],
+["love.draw"] = [=[draw() - Callback function used to draw on the screen every frame.]=],
+["love.errhand"] = [=[errhand(msg) - The error handler, used to display error messages.]=],
+["love.filedropped"] = [=[filedropped(file) - Callback function triggered when a file is dragged and dropped onto the window.]=],
+["love.focus"] = [=[focus(f) - Callback function triggered when window receives or loses focus.]=],
+["love.gamepadaxis"] = [=[gamepadaxis(joystick, axis) - Called when a Joystick's virtual gamepad axis is moved.]=],
+["love.gamepadpressed"] = [=[gamepadpressed(joystick, button) - Called when a Joystick's virtual gamepad button is pressed.]=],
+["love.gamepadreleased"] = [=[gamepadreleased(joystick, button) - Called when a Joystick's virtual gamepad button is released.]=],
+["love.joystickadded"] = [=[joystickadded(joystick) - Called when a Joystick is connected.
+
+This callback is also triggered after love.load for every Joystick which was already connected when the game started up.]=],
+["love.joystickaxis"] = [=[joystickaxis(joystick, axis, value) - Called when a joystick axis moves.]=],
+["love.joystickhat"] = [=[joystickhat(joystick, hat, direction) - Called when a joystick hat direction changes.]=],
+["love.joystickpressed"] = [=[joystickpressed(joystick, button) - Called when a joystick button is pressed.]=],
+["love.joystickreleased"] = [=[joystickreleased(joystick, button) - Called when a joystick button is released.]=],
+["love.joystickremoved"] = [=[joystickremoved(joystick) - Called when a Joystick is disconnected.]=],
+["love.keypressed"] = [=[keypressed(key, scancode, isrepeat) - Callback function triggered when a key is pressed.]=],
+["love.keyreleased"] = [=[keyreleased(key) - Callback function triggered when a keyboard key is released.]=],
+["love.load"] = [=[load(arg) - This function is called exactly once at the beginning of the game.]=],
+["love.lowmemory"] = [=[lowmemory() - Callback function triggered when the system is running out of memory on mobile devices.
+
+ Mobile operating systems may forcefully kill the game if it uses too much memory, so any non-critical resource should be removed if possible (by setting all variables referencing the resources to nil, and calling collectgarbage()), when this event is triggered. Sounds and images in particular tend to use the most memory.]=],
+["love.mousefocus"] = [=[mousefocus(f) - Callback function triggered when window receives or loses mouse focus.]=],
+["love.mousemoved"] = [=[mousemoved(x, y, dx, dy) - Callback function triggered when the mouse is moved.]=],
+["love.mousepressed"] = [=[mousepressed(x, y, button, isTouch) - Callback function triggered when a mouse button is pressed.]=],
+["love.mousereleased"] = [=[mousereleased(x, y, button, isTouch) - Callback function triggered when a mouse button is released.]=],
+["love.quit"] = [=[quit() - Callback function triggered when the game is closed.]=],
+["love.resize"] = [=[resize(w, h) - Called when the window is resized, for example if the user resizes the window, or if love.window.setMode is called with an unsupported width or height in fullscreen and the window chooses the closest appropriate size.
+
+Calls to love.window.setMode will only trigger this event if the width or height of the window after the call doesn't match the requested width and height. This can happen if a fullscreen mode is requested which doesn't match any supported mode, or if the fullscreen type is 'desktop' and the requested width or height don't match the desktop resolution.]=],
+["love.run"] = [=[run() - The main function, containing the main loop. A sensible default is used when left out.]=],
+["love.textedited"] = [=[textedited(text, start, length) - Called when the candidate text for an IME (Input Method Editor) has changed.
+
+The candidate text is not the final text that the user will eventually choose. Use love.textinput for that.]=],
+["love.textinput"] = [=[textinput(text) - Called when text has been entered by the user. For example if shift-2 is pressed on an American keyboard layout, the text "@" will be generated.]=],
+["love.threaderror"] = [=[threaderror(thread, errorstr) - Callback function triggered when a Thread encounters an error.]=],
+["love.touchmoved"] = [=[touchmoved(id, x, y, pressure) - Callback function triggered when a touch press moves inside the touch screen.]=],
+["love.touchpressed"] = [=[touchpressed(id, x, y, pressure) - Callback function triggered when the touch screen is touched.]=],
+["love.touchreleased"] = [=[touchreleased(id, x, y, pressure) - Callback function triggered when the touch screen stops being touched.]=],
+["love.update"] = [=[update(dt) - Callback function triggered when a key is pressed.]=],
+["love.visible"] = [=[visible(v) - Callback function triggered when window is minimized/hidden or unminimized by the user.]=],
+["love.wheelmoved"] = [=[wheelmoved(x, y) - Callback function triggered when the mouse wheel is moved.]=],
+["love.getVersion"] = [=[getVersion() - Gets the current running version of LÖVE.]=],
+}

--- a/love_010/math.doclua
+++ b/love_010/math.doclua
@@ -1,0 +1,94 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.math"] = [=[love.math - Provides system-independent mathematical functions.]=],
+["love.math.compress"] = [=[compress(rawstring, format, level) - Compresses a string or data using a specific compression algorithm.]=],
+["love.math.decompress"] = [=[decompress(compressedData) - Decompresses a CompressedData or previously compressed string or Data object.]=],
+["love.math.gammaToLinear"] = [=[gammaToLinear(r, g, b) - Converts a color from gamma-space (sRGB) to linear-space (RGB). This is useful when doing gamma-correct rendering using colors created based on what they look like on-screen.
+
+Gamma-space sRGB has more precision in the lower end than linear RGB. Using this function to convert from sRGB to RGB can result in non-integer color values, which get truncated to integers and lose precision when used with other functions such as love.graphics.setColor.]=],
+["love.math.getRandomSeed"] = [=[getRandomSeed() - Gets the seed of the random number generator.
+
+The state is split into two numbers due to Lua's use of doubles for all number values - doubles can't accurately represent integer values above 2^53.]=],
+["love.math.getRandomState"] = [=[getRandomState() - Gets the current state of the random number generator. This returns an opaque implementation-dependent string which is only useful for later use with RandomGenerator:setState.
+
+This is different from RandomGenerator:getSeed in that getState gets the RandomGenerator's current state, whereas getSeed gets the previously set seed number.
+
+The value of the state string does not depend on the current operating system.]=],
+["love.math.isConvex"] = [=[isConvex(vertices) - Checks whether a polygon is convex.
+
+PolygonShapes in love.physics, some forms of Mesh, and polygons drawn with love.graphics.polygon must be simple convex polygons.]=],
+["love.math.linearToGamma"] = [=[linearToGamma(lr, lg, lb) - Converts a color from linear-space (RGB) to gamma-space (sRGB). This is useful when storing linear RGB color values in an image, because the linear RGB color space has less precision than sRGB for dark colors, which can result in noticeable color banding when drawing.
+
+In general, colors chosen based on what they look like on-screen are already in gamma-space and should not be double-converted. Colors calculated using math are often in the linear RGB space.]=],
+["love.math.newBezierCurve"] = [=[newBezierCurve(vertices) - Creates a new BezierCurve object.
+
+The number of vertices in the control polygon determines the degree of the curve, e.g. three vertices define a quadratic (degree 2) Bézier curve, four vertices define a cubic (degree 3) Bézier curve, etc.]=],
+["love.math.newRandomGenerator"] = [=[newRandomGenerator() - Creates a new RandomGenerator object which is completely independent of other RandomGenerator objects and random functions.]=],
+["love.math.noise"] = [=[noise(x) - Generates a Simplex or Perlin noise value in 1-4 dimensions.
+
+Simplex noise is closely related to Perlin noise. It is widely used for procedural content generation.
+
+There are many webpages which discuss Perlin and Simplex noise in detail.]=],
+["love.math.random"] = [=[random() - Generates a pseudo-random number in a platform independent manner.]=],
+["love.math.randomNormal"] = [=[randomNormal(stddev, mean) - Get a normally distributed pseudo random number.]=],
+["love.math.setRandomSeed"] = [=[setRandomSeed(seed) - Sets the seed of the random number generator using the specified integer number.]=],
+["love.math.setRandomState"] = [=[setRandomState(state) - Gets the current state of the random number generator. This returns an opaque implementation-dependent string which is only useful for later use with RandomGenerator:setState.
+
+This is different from RandomGenerator:getSeed in that getState gets the RandomGenerator's current state, whereas getSeed gets the previously set seed number.
+
+The value of the state string does not depend on the current operating system.]=],
+["love.math.triangulate"] = [=[triangulate(polygon) - Triangulate a simple polygon.]=],
+}

--- a/love_010/mouse.doclua
+++ b/love_010/mouse.doclua
@@ -1,0 +1,93 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.mouse"] = [=[love.mouse - Provides an interface to the user's mouse.]=],
+["love.mouse.getCursor"] = [=[getCursor() - Gets the current Cursor.]=],
+["love.mouse.getPosition"] = [=[getPosition() - Returns the current position of the mouse.]=],
+["love.mouse.getRelativeMode"] = [=[getRelativeMode() - Gets whether relative mode is enabled for the mouse.
+
+If relative mode is enabled, the cursor is hidden and doesn't move when the mouse does, but relative mouse motion events are still generated via love.mousemoved. This lets the mouse move in any direction indefinitely without the cursor getting stuck at the edges of the screen.
+
+The reported position of the mouse is not updated while relative mode is enabled, even when relative mouse motion events are generated.]=],
+["love.mouse.getSystemCursor"] = [=[getSystemCursor(ctype) - Gets a Cursor object representing a system-native hardware cursor.
+
+ Hardware cursors are framerate-independent and work the same way as normal operating system cursors. Unlike drawing an image at the mouse's current coordinates, hardware cursors never have visible lag between when the mouse is moved and when the cursor position updates, even at low framerates.]=],
+["love.mouse.getX"] = [=[getX() - Returns the current x position of the mouse.]=],
+["love.mouse.getY"] = [=[getY() - Returns the current y position of the mouse.]=],
+["love.mouse.hasCursor"] = [=[hasCursor() - Gets whether cursor functionality is supported.
+
+If it isn't supported, calling love.mouse.newCursor and love.mouse.getSystemCursor will cause an error. Mobile devices do not support cursors.]=],
+["love.mouse.isDown"] = [=[isDown(button, ...) - Checks whether a certain mouse button is down. This function does not detect mousewheel scrolling; you must use the love.wheelmoved (or love.mousepressed in version 0.9.2 and older) callback for that.]=],
+["love.mouse.isGrabbed"] = [=[isGrabbed() - Checks if the mouse is grabbed.]=],
+["love.mouse.isVisible"] = [=[isVisible() - Checks if the cursor is visible.]=],
+["love.mouse.newCursor"] = [=[newCursor(imageData, hotx, hoty) - Creates a new hardware Cursor object from an image file or ImageData.
+
+Hardware cursors are framerate-independent and work the same way as normal operating system cursors. Unlike drawing an image at the mouse's current coordinates, hardware cursors never have visible lag between when the mouse is moved and when the cursor position updates, even at low frameratesn
+
+The hot spot is the point the operating system uses to determine what was clicked and at what position the mouse cursor is. For example, the normal arrow pointer normally has its hot spot at the top left of the image, but a crosshair cursor might have it in the middle.]=],
+["love.mouse.setCursor"] = [=[setCursor() - Sets the current mouse cursor.
+
+Resets the current mouse cursor to the default when called without arguments.]=],
+["love.mouse.setGrabbed"] = [=[setGrabbed(grab) - Grabs the mouse and confines it to the window.]=],
+["love.mouse.setPosition"] = [=[setPosition(x, y) - Sets the position of the mouse.]=],
+["love.mouse.setRelativeMode"] = [=[setRelativeMode(enable) - Sets whether relative mode is enabled for the mouse.
+
+When relative mode is enabled, the cursor is hidden and doesn't move when the mouse does, but relative mouse motion events are still generated via love.mousemoved. This lets the mouse move in any direction indefinitely without the cursor getting stuck at the edges of the screen.
+
+The reported position of the mouse is not updated while relative mode is enabled, even when relative mouse motion events are generated.]=],
+["love.mouse.setVisible"] = [=[setVisible(visible) - Sets the visibility of the cursor.]=],
+["love.mouse.setX"] = [=[setX(x) - Sets the current X position of the mouse.]=],
+["love.mouse.setY"] = [=[setY(y) - Sets the current Y position of the mouse.]=],
+}

--- a/love_010/physics.doclua
+++ b/love_010/physics.doclua
@@ -1,0 +1,114 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.physics"] = [=[love.physics - Can simulate 2D rigid body physics in a realistic manner. This module is based on Box2D, and this API corresponds to the Box2D API as closely as possible.]=],
+["love.physics.getDistance"] = [=[getDistance(fixture1, fixture2) - Returns the two closest points between two fixtures and their distance.]=],
+["love.physics.getMeter"] = [=[getMeter() - Get the scale of the world.
+
+The world scale is the number of pixels per meter. Try to keep your shape sizes less than 10 times this scale.
+
+This is important because the physics in Box2D is tuned to work well for objects of size 0.1m up to 10m. All physics coordinates are divided by this number for the physics calculations.]=],
+["love.physics.newBody"] = [=[newBody(world, x, y, type) - Creates a new body.
+
+There are three types of bodies. Static bodies do not move, have a infinite mass, and can be used for level boundaries. Dynamic bodies are the main actors in the simulation, they collide with everything. Kinematic bodies do not react to forces and only collide with dynamic bodies.
+
+The mass of the body gets calculated when a Fixture is attached or removed, but can be changed at any time with Body:setMass or Body:resetMassData.]=],
+["love.physics.newChainShape"] = [=[newChainShape(loop, x1, y1, x2, y2, ...) - Creates a new ChainShape.]=],
+["love.physics.newCircleShape"] = [=[newCircleShape(radius) - Creates a new CircleShape.]=],
+["love.physics.newDistanceJoint"] = [=[newDistanceJoint(body1, body2, x1, y1, x2, y2, collideConnected) - Create a distance joint between two bodies.
+
+This joint constrains the distance between two points on two bodies to be constant. These two points are specified in world coordinates and the two bodies are assumed to be in place when this joint is created. The first anchor point is connected to the first body and the second to the second body, and the points define the length of the distance joint.]=],
+["love.physics.newEdgeShape"] = [=[newEdgeShape(x1, y1, x2, y2) - Creates a edge shape.]=],
+["love.physics.newFixture"] = [=[newFixture(body, shape, density) - Creates and attaches a Fixture to a body.]=],
+["love.physics.newFrictionJoint"] = [=[newFrictionJoint(body1, body2, x, y, collideConnected) - Create a friction joint between two bodies. A FrictionJoint applies friction to a body.]=],
+["love.physics.newGearJoint"] = [=[newGearJoint(joint1, joint2, ratio, collideConnected) - Create a gear joint connecting two joints.
+
+The gear joint connects two joints that must be either prismatic or revolute joints. Using this joint requires that the joints it uses connect their respective bodies to the ground and have the ground as the first body. When destroying the bodies and joints you must make sure you destroy the gear joint before the other joints.
+
+The gear joint has a ratio the determines how the angular or distance values of the connected joints relate to each other. The formula coordinate1 + ratio * coordinate2 always has a constant value that is set when the gear joint is created.]=],
+["love.physics.newMouseJoint"] = [=[newMouseJoint(body, x, y) - Create a joint between a body and the mouse.
+
+This joint actually connects the body to a fixed point in the world. To make it follow the mouse, the fixed point must be updated every timestep (example below).
+
+The advantage of using a MouseJoint instead of just changing a body position directly is that collisions and reactions to other joints are handled by the physics engine.]=],
+["love.physics.newPolygonShape"] = [=[newPolygonShape(x1, y1, x2, y2, ...) - Creates a new PolygonShape.
+
+This shape can have 8 vertices at most, and must form a convex shape.]=],
+["love.physics.newPrismaticJoint"] = [=[newPrismaticJoint(body1, body2, x, y, ax, ay, collideConnected) - Create a prismatic joints between two bodies.
+
+A prismatic joint constrains two bodies to move relatively to each other on a specified axis. It does not allow for relative rotation. Its definition and operation are similar to a revolute joint, but with translation and force substituted for angle and torque.]=],
+["love.physics.newPulleyJoint"] = [=[newPulleyJoint(body1, body2, gx1, gy1, gx2, gy2, x1, y1, x2, y2, ratio, collideConnected) - Create a pulley joint to join two bodies to each other and the ground.
+
+The pulley joint simulates a pulley with an optional block and tackle. If the ratio parameter has a value different from one, then the simulated rope extends faster on one side than the other. In a pulley joint the total length of the simulated rope is the constant length1 + ratio * length2, which is set when the pulley joint is created.
+
+Pulley joints can behave unpredictably if one side is fully extended. It is recommended that the method setMaxLengths  be used to constrain the maximum lengths each side can attain.]=],
+["love.physics.newRectangleShape"] = [=[newRectangleShape(width, height) - Shorthand for creating rectangluar PolygonShapes.
+
+By default, the local origin is located at the center of the rectangle as opposed to the top left for graphics.]=],
+["love.physics.newRevoluteJoint"] = [=[newRevoluteJoint(body1, body2, x, y, collideConnected) - Creates a pivot joint between two bodies.
+
+This joint connects two bodies to a point around which they can pivot.]=],
+["love.physics.newRopeJoint"] = [=[newRopeJoint(body1, body2, x1, y1, x2, y2, maxLength, collideConnected) - Create a joint between two bodies. Its only function is enforcing a max distance between these bodies.]=],
+["love.physics.newWeldJoint"] = [=[newWeldJoint(body1, body2, x, y, collideConnected) - Create a friction joint between two bodies. A WeldJoint essentially glues two bodies together.]=],
+["love.physics.newWheelJoint"] = [=[newWheelJoint(body1, body2, x, y, ax, ay, collideConnected) - Creates a wheel joint.]=],
+["love.physics.newWorld"] = [=[newWorld(xg, yg, sleep) - Creates a new World.]=],
+["love.physics.setMeter"] = [=[setMeter(scale) - Sets the pixels to meter scale factor.
+
+All coordinates in the physics module are divided by this number and converted to meters, and it creates a convenient way to draw the objects directly to the screen without the need for graphics transformations.
+
+It is recommended to create shapes no larger than 10 times the scale. This is important because Box2D is tuned to work well with shape sizes from 0.1 to 10 meters. The default meter scale is 30.
+
+love.physics.setMeter does not apply retroactively to created objects. Created objects retain their meter coordinates but the scale factor will affect their pixel coordinates.]=],
+}

--- a/love_010/sound.doclua
+++ b/love_010/sound.doclua
@@ -1,0 +1,61 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.sound"] = [=[love.sound - This module is responsible for decoding sound files. It can't play the sounds, see love.audio for that.]=],
+["love.sound.newDecoder"] = [=[newDecoder(file, buffer) - Attempts to find a decoder for the encoded sound data in the specified file.]=],
+["love.sound.newSoundData"] = [=[newSoundData(filename) - Creates new SoundData from a file. It's also possible to create SoundData with a custom sample rate, channel and bit depth.
+
+The sound data will be decoded to the memory in a raw format. It is recommended to create only short sounds like effects, as a 3 minute song uses 30 MB of memory this way.]=],
+}

--- a/love_010/system.doclua
+++ b/love_010/system.doclua
@@ -1,0 +1,66 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.system"] = [=[love.system - Provides access to information about the user's system.]=],
+["love.system.getClipboardText"] = [=[getClipboardText() - Gets text from the clipboard.]=],
+["love.system.getOS"] = [=[getOS() - Gets the current operating system. In general, LÖVE abstracts away the need to know the current operating system, but there are a few cases where it can be useful (especially in combination with os.execute.)]=],
+["love.system.getPowerInfo"] = [=[getPowerInfo() - Gets information about the system's power supply.]=],
+["love.system.getProcessorCount"] = [=[getProcessorCount() - Gets the number of CPU cores in the system.
+
+The number includes the threads reported if technologies such as Intel's Hyper-threading are enabled. For example, on a 4-core CPU with Hyper-threading, this function will return 8.]=],
+["love.system.openURL"] = [=[openURL(url) - Opens a URL with the user's web or file browser.]=],
+["love.system.setClipboardText"] = [=[setClipboardText(text) - Puts text in the clipboard.]=],
+["love.system.vibrate"] = [=[vibrate(seconds) - Causes the device to vibrate, if possible. Currently this will only work on Android and iOS devices that have a built-in vibration motor.]=],
+}

--- a/love_010/thread.doclua
+++ b/love_010/thread.doclua
@@ -1,0 +1,68 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.thread"] = [=[love.thread - Allows you to work with threads.
+
+Threads are separate Lua environments, running in parallel to the main code. As their code runs separately, they can be used to compute complex operations without adversely affecting the frame rate of the main thread. However, as they are separate environments, they cannot access the variables and functions of the main thread, and communication between threads is limited.
+
+All LOVE objects (userdata) are shared among threads so you'll only have to send their references across threads. You may run into concurrency issues if you manipulate an object on multiple threads at the same time.
+
+When a Thread is started, it only loads the love.thread module. Every other module has to be loaded with require.]=],
+["love.thread.getChannel"] = [=[getChannel(name) - Creates or retrieves a named thread channel.]=],
+["love.thread.newChannel"] = [=[newChannel() - Create a new unnamed thread channel.
+
+One use for them is to pass new unnamed channels to other threads via Channel:push]=],
+["love.thread.newThread"] = [=[newThread(filename) - Creates a new Thread from a File or Data object.]=],
+}

--- a/love_010/timer.doclua
+++ b/love_010/timer.doclua
@@ -1,0 +1,63 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.timer"] = [=[love.timer - Provides an interface to the user's clock.]=],
+["love.timer.getAverageDelta"] = [=[getAverageDelta() - Returns the average delta time (seconds per frame) over the last second.]=],
+["love.timer.getDelta"] = [=[getDelta() - Returns the time between the last two frames.]=],
+["love.timer.getFPS"] = [=[getFPS() - Returns the current frames per second.]=],
+["love.timer.getTime"] = [=[getTime() - Returns the value of a timer with an unspecified starting time. This function should only be used to calculate differences between points in time, as the starting time of the timer is unknown.]=],
+["love.timer.sleep"] = [=[sleep(s) - Sleeps the program for the specified amount of time.]=],
+["love.timer.step"] = [=[step() - Measures the time between two frames. Calling this changes the return value of love.timer.getDelta.]=],
+}

--- a/love_010/touch.doclua
+++ b/love_010/touch.doclua
@@ -1,0 +1,60 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.touch"] = [=[love.touch - Provides an interface to touch-screen presses.]=],
+["love.touch.getPosition"] = [=[getPosition(id) - Gets the current position of the specified touch-press, in pixels.]=],
+["love.touch.getPressure"] = [=[getPressure(id) - Gets the current pressure of the specified touch-press.]=],
+["love.touch.getTouches"] = [=[getTouches() - Gets a list of all active touch-presses.]=],
+}

--- a/love_010/video.doclua
+++ b/love_010/video.doclua
@@ -1,0 +1,60 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.video"] = [=[love.video - This module is responsible for decoding, controlling, and streaming video files.
+
+It can't draw the videos, see love.graphics.newVideo and Video objects for that.]=],
+["love.video.newVideoStream"] = [=[newVideoStream(filename) - Creates a new VideoStream. Currently only Ogg Theora video files are supported. VideoStreams can't draw videos, see love.graphics.newVideo for that.]=],
+}

--- a/love_010/window.doclua
+++ b/love_010/window.doclua
@@ -1,0 +1,121 @@
+local BASE_URL = "https://love2d.org"
+
+--- Quickhelp Documentation (ctrl-J)
+-- This is called when the user invokes quick help via ctrl-j, or by
+-- having the quickhelp panel open and set to autolookup
+-- @param name The name to get documentation for.
+-- @return the documentation as an HTML or plain text string
+function getDocumentation(name)
+    -- Use for development
+    -- disableCache()
+
+    local data = fetchURL(getDocumentationUrl(name))
+
+    local contentTag = [[<div id="bodyContent">]]
+    local footerTag = [[<div class="printfooter]]
+
+    local contentPos = data:find(contentTag)
+    local footerPos = data:find(footerTag)
+
+    if contentPos == nil then
+        return "<html><h3>" .. name .. "</h3>Could not load from Love wiki.<br><br><b>[data from love2d.org]</b></html>"
+    end
+
+    data = data:sub(contentPos, footerPos)
+
+    data =  data:gsub([[href="]], [[href="]]..BASE_URL)
+    data =  data:gsub([[src="]], [[src="]]..BASE_URL)
+
+    data = "<html><h3>" .. name .. "</h3>" .. data .. "<br><br><b>[data from love2d.org]</b></html>"
+
+    return data
+end
+
+--- External Documentation URL (shift-F1)
+-- This is called by shift-F1 on the symbol, or by the
+-- external documentation button on the quick help panel
+-- @param name The name to get documentation for.
+-- @return the URL of the external documentation
+function getDocumentationUrl(name)
+    return BASE_URL .. "/wiki/" .. name
+end
+
+
+--- Quick Navigation Tooltip Text, (ctrl-hover on symbol)
+-- This is called when the user ctrl-hovers over a symbol
+-- @param name The name to get documentation for.
+-- @return the documentation as a plain text string
+function getQuickNavigateDocumentation(name)
+    local sig = SIGNATURES[name]
+    if not sig then return name end
+    return SIGNATURES[name]
+end
+
+
+SIGNATURES = {
+["love.window"] = [=[love.window - Provides an interface for modifying and retrieving information about the program's window.]=],
+["love.window.close"] = [=[close() - Closes the window. It can be reopened with love.window.setMode.]=],
+["love.window.fromPixels"] = [=[fromPixels(pixelvalue) - Converts a number from pixels to density-independent units.
+
+The pixel density inside the window might be greater (or smaller) than the "size" of the window. For example on a retina screen in Mac OS X with the highdpi window flag enabled, the window may take up the same physical size as an 800x600 window, but the area inside the window uses 1600x1200 pixels. love.window.fromPixels(1600) would return 800 in that case.
+
+This function converts coordinates from pixels to the size users are expecting them to display at onscreen. love.window.toPixels does the opposite. The highdpi window flag must be enabled to use the full pixel density of a Retina screen on Mac OS X and iOS. The flag currently does nothing on Windows and Linux, and on Android it is effectively always enabled.
+
+Most LÖVE functions return values and expect arguments in terms of pixels rather than density-independent units.]=],
+["love.window.getDisplayName"] = [=[getDisplayName(displayindex) - Gets the name of a display.]=],
+["love.window.getFullscreen"] = [=[getFullscreen() - Gets whether the window is fullscreen.]=],
+["love.window.getFullscreenModes"] = [=[getFullscreenModes(display) - Gets a list of supported fullscreen modes.]=],
+["love.window.getIcon"] = [=[getIcon() - Gets the window icon.]=],
+["love.window.getMode"] = [=[getMode() - Returns the current display mode.]=],
+["love.window.getPixelScale"] = [=[getPixelScale() - Gets the DPI scale factor associated with the window.
+
+The pixel density inside the window might be greater (or smaller) than the "size" of the window. For example on a retina screen in Mac OS X with the highdpi window flag enabled, the window may take up the same physical size as an 800x600 window, but the area inside the window uses 1600x1200 pixels. love.window.getPixelScale() would return 2.0 in that case.
+
+The love.window.fromPixels and love.window.toPixels functions can also be used to convert between units.
+
+The highdpi window flag must be enabled to use the full pixel density of a Retina screen on Mac OS X and iOS. The flag currently does nothing on Windows and Linux, and on Android it is effectively always enabled.]=],
+["love.window.getPosition"] = [=[getPosition() - Gets the position of the window on the screen.
+
+The window position is in the coordinate space of the display it is currently in.]=],
+["love.window.getTitle"] = [=[getTitle() - Gets the window title.]=],
+["love.window.hasFocus"] = [=[hasFocus() - Checks if the game window has keyboard focus.]=],
+["love.window.hasMouseFocus"] = [=[hasMouseFocus() - Checks if the game window has mouse focus.]=],
+["love.window.isCreated"] = [=[isCreated() - Checks if the window has been created.]=],
+["love.window.isDisplaySleepEnabled"] = [=[isDisplaySleepEnabled() - Gets whether the display is allowed to sleep while the program is running.
+
+Display sleep is disabled by default. Some types of input (e.g. joystick button presses) might not prevent the display from sleeping, if display sleep is allowed.]=],
+["love.window.isVisible"] = [=[isVisible() - Checks if the game window is visible.
+
+The window is considered visible if it's not minimized and the program isn't hidden.]=],
+["love.window.maximize"] = [=[maximize() - Makes the window as large as possible.
+
+This function has no effect if the window isn't resizable, since it essentially programmatically presses the window's "maximize" button.]=],
+["love.window.minimize"] = [=[minimize() - Minimizes the window to the system's task bar / dock.]=],
+["love.window.requestAttention"] = [=[requestAttention(continuous) - Causes the window to request the attention of the user if it is not in the foreground.
+
+In Windows the taskbar icon will flash, and in OS X the dock icon will bounce.]=],
+["love.window.setDisplaySleepEnabled"] = [=[setDisplaySleepEnabled(enable) - Sets whether the display is allowed to sleep while the program is running.
+
+Display sleep is disabled by default. Some types of input (e.g. joystick button presses) might not prevent the display from sleeping, if display sleep is allowed.]=],
+["love.window.setFullscreen"] = [=[setFullscreen(fullscreen) - Enters or exits fullscreen. The display to use when entering fullscreen is chosen based on which display the window is currently in, if multiple monitors are connected.
+
+If fullscreen mode is entered and the window size doesn't match one of the monitor's display modes (in normal fullscreen mode) or the window size doesn't match the desktop size (in 'desktop' fullscreen mode), the window will be resized appropriately. The window will revert back to its original size again when fullscreen mode is exited using this function.]=],
+["love.window.setIcon"] = [=[setIcon(imagedata) - Sets the window icon until the game is quit. Not all operating systems support very large icon images.]=],
+["love.window.setMode"] = [=[setMode(width, height, flags) - Sets the display mode and properties of the window.
+
+If width or height is 0, setMode will use the width and height of the desktop.
+
+Changing the display mode may have side effects: for example, canvases will be cleared and values sent to shaders with Shader:send will be erased. Make sure to save the contents of canvases beforehand or re-draw to them afterward if you need to.]=],
+["love.window.setPosition"] = [=[setPosition(x, y, display) - Sets the position of the window on the screen.
+
+The window position is in the coordinate space of the specified display.]=],
+["love.window.setTitle"] = [=[setTitle(title) - Sets the window title.]=],
+["love.window.showMessageBox"] = [=[showMessageBox(title, message, type, attachtowindow) - Displays a message box dialog above the love window. The message box contains a title, optional text, and buttons.]=],
+["love.window.toPixels"] = [=[toPixels(value) - Converts a number from density-independent units to pixels.
+
+The pixel density inside the window might be greater (or smaller) than the "size" of the window. For example on a retina screen in Mac OS X with the highdpi window flag enabled, the window may take up the same physical size as an 800x600 window, but the area inside the window uses 1600x1200 pixels. love.window.toPixels(800) would return 1600 in that case.
+
+This is used to convert coordinates from the size users are expecting them to display at onscreen to pixels. love.window.fromPixels does the opposite. The highdpi window flag must be enabled to use the full pixel density of a Retina screen on Mac OS X and iOS. The flag currently does nothing on Windows and Linux, and on Android it is effectively always enabled.
+
+Most LÖVE functions return values and expect arguments in terms of pixels rather than density-independent units.]=],
+}


### PR DESCRIPTION
Also adds in the actual documentation files for 0.10.0. 

Since the LUA plguin for IDEA now supports external documentation and custom signatures, thought I'd add that in. Has support for inline links and images. Ctrl/Command-Hover for signatures using the top variant, and Ctrl-J brings up the Wiki.

This is my first time using LUA so definitely take a look to see if there's anything off in the new doclua files. Horrified at what is happening for parsing the HTML, but it would seem our alternative is reliant of C-libraries being installed on the system. 
